### PR TITLE
chore(lib-storage): stop bundling fs in browsers

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -53,6 +53,7 @@
     }
   },
   "browser": {
+    "fs": false,
     "stream": "stream-browserify",
     "./runtimeConfig": "./src/runtimeConfig.browser"
   },


### PR DESCRIPTION
Webpack5 fails when bundler lib-storage because it requires 'fs' module. This change explicitly disable bundling fs module in browsers.

### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
