### PR TITLE
test: unblock generic client test

### DIFF
--- a/.github/workflows/generic-client-tests.yml
+++ b/.github/workflows/generic-client-tests.yml
@@ -34,7 +34,14 @@ jobs:
           cd codegen
           ./gradlew clean smithy-aws-typescript-codegen:build generic-client-test-codegen:build
 
+      - name: link service-client-documentation-generator
+        run: |
+          cd packages/service-client-documentation-generator
+          yarn install && yarn build
+          yarn link
+
       - name: build generic client
         run: |
           cd codegen/generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/aws-echo-service/typescript-codegen/
+          yarn link "@aws-sdk/service-client-documentation-generator"
           yarn install && yarn build


### PR DESCRIPTION
client-dencumentation-generator package was renamed to service-client-
documentation-generator but not release yet. Hense the generic client
test is blocked because it cannot download the new package.

This change link the package from local. It will be reverted after
next release

### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
